### PR TITLE
Add Greek/NATO alphabet to RandomNameGenerator.cs

### DIFF
--- a/RandomNameGenerator.cs
+++ b/RandomNameGenerator.cs
@@ -771,14 +771,14 @@ namespace ModularEncountersSpawner {
 			
 			if(newPattern.Contains("NatoLetter") == true) {
 
-				var randString = NeutralNouns[Rnd.Next(0, NeutralNouns.Length)];
+				var randString = NatoLetter[Rnd.Next(0, NatoLetter.Length)];
 				newPattern = newPattern.Replace("NatoLetter", randString);
 
 			}
 			
 			if(newPattern.Contains("GreekLetter") == true) {
 
-				var randString = NeutralNouns[Rnd.Next(0, NeutralNouns.Length)];
+				var randString = GreekLetter[Rnd.Next(0, GreekLetter.Length)];
 				newPattern = newPattern.Replace("GreekLetter", randString);
 
 			}

--- a/RandomNameGenerator.cs
+++ b/RandomNameGenerator.cs
@@ -455,6 +455,68 @@ namespace ModularEncountersSpawner {
 			"Lancaster"
 			
 		};
+		
+		public static string[] NatoLetter = {
+
+			"Alpha",
+			"Bravo",
+			"Charlie",
+			"Delta",
+			"Echo",
+			"Foxtrot",
+			"Golf",
+			"Hotel",
+			"India",
+			"Juliett",
+			"Kilo",
+			"Lima",
+			"Mike",
+			"November",
+			"Oscar",
+			"Papa",
+			"Quebec",
+			"Romeo",
+			"Sierra",
+			"Tango",
+			"Uniform",
+			"Victor",
+			"Whiskey",
+			"X-Ray",
+			"Yankee",
+			"Zulu"
+
+		};
+		
+		public static string[] GreekLetter = {
+
+			"Alpha",
+			"Beta",
+			"Gamma",
+			"Delta",
+			"Epsilon",
+			"Zeta",
+			"Eta",
+			"Theta",
+			"Iota",
+			"Kappa",
+			"Lambda",
+			"Mu",
+			"Nu",
+			"Xi",
+			"Omicron",
+			"Pi",
+			"Rho",
+			"Sigma"
+			"Tau",
+			"Upsilon",
+			"Phi",
+			"Chi",
+			"Psi",
+			"Omega"
+
+		};
+		
+		
 
 		public static string CreateRandomNameFromPattern(string pattern) {
 
@@ -704,6 +766,20 @@ namespace ModularEncountersSpawner {
 				string randString = CharStringAll[Rnd.Next(0, CharStringAll.Length)].ToString();
 
 				newPattern = ReplaceFirstOccurence("RandomChar", randString, newPattern);
+
+			}
+			
+			if(newPattern.Contains("NatoLetter") == true) {
+
+				var randString = NeutralNouns[Rnd.Next(0, NeutralNouns.Length)];
+				newPattern = newPattern.Replace("NatoLetter", randString);
+
+			}
+			
+			if(newPattern.Contains("GreekLetter") == true) {
+
+				var randString = NeutralNouns[Rnd.Next(0, NeutralNouns.Length)];
+				newPattern = newPattern.Replace("GreekLetter", randString);
 
 			}
 


### PR DESCRIPTION
This PR aims to add **written-out** versions of the **Greek** & **NATO** alphabet to the Random Name Generator present in MES. 

The inclusion of just these name patterns allows the creation of hundreds of simple, yet unique combinations. The words in **bold** are taken randomly from the Random Name Generator:
- **Lancaster**-class Freighter **Tau**-**284**
- Strike Unit **Charlie**-**04**
- Refinery Outpost **Iota**-**12**
- **Barton**-class Capital Ship "**Omega**"

Please review and test these changes locally before potentially pushing to Steam, as I was unable to test/confirm them myself (as I don't have an offline build of MES).