### PR TITLE
Turret range override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# Binaries and Libraries
+*.dll

--- a/Configuration/ConfigGeneral.cs
+++ b/Configuration/ConfigGeneral.cs
@@ -111,8 +111,10 @@ namespace ModularEncountersSpawner.Configuration{
 		public string[] WeaponReplacerWhitelist {get; set;}
 		public string[] WeaponReplacerTargetBlacklist {get; set;}
 		public string[] WeaponReplacerTargetWhitelist {get; set;}
-		
-		public bool UseGlobalBlockReplacer {get; set;}
+
+        public bool WeaponReplacerUseMaxRangeOverride {get; set;}
+        public float WeaponReplacerMaxRangeOverride {get; set;}
+        public bool UseGlobalBlockReplacer {get; set;}
 		public string[] GlobalBlockReplacerReference {get; set;}
 		public string[] GlobalBlockReplacerProfiles {get; set;}
 		
@@ -164,6 +166,8 @@ namespace ModularEncountersSpawner.Configuration{
 			WeaponReplacerWhitelist = new string[]{};
 			WeaponReplacerTargetBlacklist = new string[]{};
 			WeaponReplacerTargetWhitelist = new string[]{};
+			WeaponReplacerUseMaxRangeOverride = false;
+			WeaponReplacerMaxRangeOverride = 800;
 			UseGlobalBlockReplacer = false;
 			GlobalBlockReplacerReference = new string[]{};
 			GlobalBlockReplacerProfiles = new string[]{};

--- a/GridBuilderManipulation.cs
+++ b/GridBuilderManipulation.cs
@@ -2607,12 +2607,17 @@ namespace ModularEncountersSpawner{
 							turretBuilder.ColorMaskHSV = oldColor;
 							
 							var turretDef = (MyLargeTurretBaseDefinition)weaponProfile.BlockDefinition;
-							
-							if(turretDef.MaxRangeMeters <= 800){
-								
+
+							if (turretDef.MaxRangeMeters <= 800)
+							{
+
 								turretBuilder.Range = turretDef.MaxRangeMeters;
-								
-								
+
+							}else if (Settings.General.WeaponReplacerUseMaxRangeOverride)
+                            {
+
+								turretBuilder.Range = Math.Min(turretDef.MaxRangeMeters, Settings.General.WeaponReplacerMaxRangeOverride);
+
 							}else if(gridBlockCount <= 800){
 								
 								if(turretDef.MaxRangeMeters <= 800){

--- a/GridBuilderManipulation.cs
+++ b/GridBuilderManipulation.cs
@@ -2608,39 +2608,19 @@ namespace ModularEncountersSpawner{
 							
 							var turretDef = (MyLargeTurretBaseDefinition)weaponProfile.BlockDefinition;
 
-							if (turretDef.MaxRangeMeters <= 800)
-							{
 
-								turretBuilder.Range = turretDef.MaxRangeMeters;
-
-							}else if (Settings.General.WeaponReplacerUseMaxRangeOverride)
+							if (Settings.General.WeaponReplacerUseMaxRangeOverride)
                             {
 
 								turretBuilder.Range = Math.Min(turretDef.MaxRangeMeters, Settings.General.WeaponReplacerMaxRangeOverride);
 
-							}else if(gridBlockCount <= 800){
-								
-								if(turretDef.MaxRangeMeters <= 800){
-									
-									turretBuilder.Range = turretDef.MaxRangeMeters;
-									
-								}else{
-									
-									turretBuilder.Range = 800;
-									
-								}
-								
-							}else{
-								
-								var randRange = (float)Rnd.Next(800, (int)gridBlockCount);
-								
-								if(randRange > turretDef.MaxRangeMeters){
-									
-									randRange = turretDef.MaxRangeMeters;
-									
-								}
-								
-								turretBuilder.Range = randRange;
+							} else
+							{
+
+								const float DefaultTurretRange = 800;
+								var randRange = (float)Rnd.Next((int)DefaultTurretRange, Math.Max((int)DefaultTurretRange,(int)gridBlockCount));
+								turretBuilder.Range = Math.Min(turretDef.MaxRangeMeters, randRange);
+
 							}
 
 							turretBuilder.TargetMissiles = true;

--- a/GridBuilderManipulation.cs
+++ b/GridBuilderManipulation.cs
@@ -2636,15 +2636,15 @@ namespace ModularEncountersSpawner{
 								}
 								
 								turretBuilder.Range = randRange;
-								turretBuilder.TargetMissiles = true;
-								turretBuilder.TargetCharacters = true;
-								turretBuilder.TargetSmallGrids = true;
-								turretBuilder.TargetLargeGrids = true;
-								turretBuilder.TargetStations = true;
-								turretBuilder.TargetNeutrals = targetNeutralSetting;
-								
 							}
-							
+
+							turretBuilder.TargetMissiles = true;
+							turretBuilder.TargetCharacters = true;
+							turretBuilder.TargetSmallGrids = true;
+							turretBuilder.TargetLargeGrids = true;
+							turretBuilder.TargetStations = true;
+							turretBuilder.TargetNeutrals = targetNeutralSetting;
+
 							cubeGrid.CubeBlocks.Add(turretBuilder as MyObjectBuilder_CubeBlock);
 							
 						}else{


### PR DESCRIPTION
Added two properties to the ConfigGeneral for:

1. WeaponReplacerUseMaxRangeOverride: Toggle on whether to use the override, vs normal existing function (maxweaponrange or rand of 800->gridBlocks)
2. WeaponReplacerMaxRangeOverride: The max range value to override with.

I potentially could have just done this with just 1 xml tag and offered a lot more general configuration, but I wanted to keep things clear and not change the original intent of your code (as I could best guess from reading it). I did make a last commit trying to simplify that code section a fair bit, feel free to disregard if you prefer the explicit if statements for each case. 

I'm happy to add the tags to the documentation as well on your gist, just let me know. Of course if you have a better approach to this or it violates your intended style, feel free to disregard the PR entirely. Thanks for all your work on MES and RivalAI!


